### PR TITLE
Converting returned bytes object to string manually is causing it to be .formatted as "b'contents'". If you tell lxml to return unicode, you get the proper "contents".

### DIFF
--- a/readability/htmls.py
+++ b/readability/htmls.py
@@ -105,7 +105,8 @@ def shorten_title(doc):
 
 def get_body(doc):
     [ elem.drop_tree() for elem in doc.xpath('.//script | .//link | .//style') ]
-    raw_html = str(tostring(doc.body or doc))
+    raw_html = tostring(doc.body or doc, encoding='unicode')
+
     try:
         cleaned = clean_attributes(raw_html)
         return cleaned
@@ -126,7 +127,7 @@ def get_image_from_meta(doc):
         og_image_content = og_image[0].get("content")
         if og_image_content:
             return og_image_content
-    
+
     twitter_image = doc.xpath('/html/head/meta[@name="twitter:image:src"]')
     if twitter_image:
         twitter_image_content = twitter_image[0].get("content")
@@ -158,7 +159,7 @@ BAD_IMAGE_PATTERN = re.compile("avatar", re.I)
 BAD_IMAGE_BLOCK_PATTERN = re.compile("comment", re.I)
 
 def get_image_in_bad_site(doc):
-    
+
     items  = [
         "#content", "#content-wrapper", "#wrapper",
         ".content", ".content-wrapper", ".wrapper"


### PR DESCRIPTION
Minimal example:

```
gotPage = wg.getpage('http://www.google.com')
doc = readability.readability.Document(gotPage, base_url=srcUrl, debug=True)
doc.parse()
print(doc.content())
```

where `wg.getpage()` returns the page contents as a unicode string. `doc.content()` returns:

```
b'<body class="hp vasq" alink="#dd4b39" bgcolor="#fff" id="gsr" link="#12c" text="#222" vlink="#61c"> ...... [Snip a bunch of stuff] ..... </ul><a class="gb_H gb_Vb" href="http://www.google.com/intl/en/options/">Even more from Google</a></div></div><div id="xjsd"></div><div id="xjsi" data-jiis="bp"></div></div></body>'
```

The critical thing being the `b'{contents}'` is actually _in_ the output string. This fixes it.

It's really a one-line change, my editor trims trailing spaces on save. That's what the other three changes are from.

And please, please, please turn on the issue tracker. You have it off for some reason.
