### PR TITLE
Shut up irritating `lxml` change warning.

### DIFF
--- a/readability/htmls.py
+++ b/readability/htmls.py
@@ -105,10 +105,8 @@ def shorten_title(doc):
 
 def get_body(doc):
     [ elem.drop_tree() for elem in doc.xpath('.//script | .//link | .//style') ]
-    if len(doc.body):
-        raw_html = tostring(doc.body, encoding='unicode')
-    else:
-        raw_html = tostring(doc, encoding='unicode')
+
+    raw_html = tostring(doc.body if len(doc.body) else doc, encoding='unicode')
 
 
     try:

--- a/readability/htmls.py
+++ b/readability/htmls.py
@@ -105,7 +105,11 @@ def shorten_title(doc):
 
 def get_body(doc):
     [ elem.drop_tree() for elem in doc.xpath('.//script | .//link | .//style') ]
-    raw_html = tostring(doc.body or doc, encoding='unicode')
+    if len(doc.body):
+        raw_html = tostring(doc.body, encoding='unicode')
+    else:
+        raw_html = tostring(doc, encoding='unicode')
+
 
     try:
         cleaned = clean_attributes(raw_html)


### PR DESCRIPTION
Every time readability is run, it emits:  

>  /usr/local/lib/python3.4/dist-packages/readability_lxml-0.4.0.4-py3.4.egg/readability/htmls.py:110: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.

This is cause by checking the truth value of a lxml `Element`, which they're apparently trying to change. See http://stackoverflow.com/questions/20129996/why-does-boolxml-etree-elementtree-element-evaluate-to-false

Anyways, this replaces the truth-value check with a explicit check whether the node has any children.
